### PR TITLE
Do not error if a users profile is empty

### DIFF
--- a/lib/talis/authentication/login.rb
+++ b/lib/talis/authentication/login.rb
@@ -132,7 +132,7 @@ module Talis
       private
 
       def build_user(data)
-        profile = data.fetch('profile', {})
+        profile = data['profile'] || {}
         Talis::User.build(guid: data['guid'],
                           first_name: profile['first_name'],
                           surname: profile['surname'],

--- a/lib/talis/version.rb
+++ b/lib/talis/version.rb
@@ -1,3 +1,3 @@
 module Talis
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end

--- a/spec/unit/authentication/login_spec.rb
+++ b/spec/unit/authentication/login_spec.rb
@@ -44,6 +44,20 @@ describe Talis::Authentication::Login do
         expect(@login.error).to be_nil
       end
 
+      it 'validates the login give a payload with an empty profile' do
+        allow(user_double).to receive(:build)
+
+        data = valid_login_data
+        data[:profile] = nil
+
+        options = generate_post_login_options(data)
+
+        @login.validate!(options)
+
+        expect(@login.valid?).to be true
+        expect(@login.error).to be_nil
+      end
+
       it 'returns the logged-in user' do
         expect(user_double).to receive(:build) do |login_data|
           # Shortcut the work Talis::Authentication::Token would do for real.


### PR DESCRIPTION
If a users profile is empty (i.e, they have come via trapdoor and not
filled out their profile), the build_user method doesn't quite work.

It attempts to set the profile to the empty hash - however, this fails
since the attribute is already present (behaviour of Hash#fetch)

Instead, we should look at the result of attempting to access the
profile key and use an empty hash if it is falsey.