### PR TITLE
No contributors bug

### DIFF
--- a/lib/talis/bibliography/manifestation.rb
+++ b/lib/talis/bibliography/manifestation.rb
@@ -92,7 +92,7 @@ module Talis
       # typed objects
       # @param resources [Array] an array of Metatron::ResourceData objects
       def hydrate_relationships(included_resources)
-        @contributors.map! do |contributor|
+        contributors.map! do |contributor|
           find_relationship_in_included(contributor,
                                         included_resources)
         end

--- a/lib/talis/version.rb
+++ b/lib/talis/version.rb
@@ -1,3 +1,3 @@
 module Talis
-  VERSION = '0.6.2'.freeze
+  VERSION = '0.6.3'.freeze
 end


### PR DESCRIPTION
Fixes an bug where exceptions are thrown on occasions where `Talis::Bibliography::Manifestations` do not have any contributor relationships