### PR TITLE
90%: PLAT-578 escape metatron queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
   - PERSONA_TEST_HOST: https://staging-users.talis.com
   - BLUEPRINT_TEST_HOST: https://staging-hierarchy.talis.com
-  - METATRON_TEST_HOST: https://i15dnx35r2.execute-api.eu-west-1.amazonaws.com
+  - METATRON_TEST_HOST: https://4yk6o0puk0.execute-api.eu-west-1.amazonaws.com
   - METATRON_BASE_PATH: /staging/2
   - ECHO_TEST_HOST: https://staging-analytics.talis.com
   - secure: BE2l30U/CLy50vFGV33JCu8t5sr3S0tjCVHcyvby9ChLj7SbceiL7oFhdInCfUFP5uOn9JoyAeULq0JSJK+j5tPsWVGXW0j1hJGvOjcDPA9gsvA4IpgH0WNs6eX5GZkYJIMioJB1MrRP8Hq6teUIC8fb51DQOkL8IRydD1qJsLOgebKfJHLB1hEXHUO0O4Mn3lZrJNjthZrNJG4bhBLvTnki4dmBu+vzEVBb8QMxpnNbBVUI8P3Uo4WlygOnirnW6naxBizHK7EAV6Hk221eTyarepe9u0CpWPXVG5XiHtedUDUU6SdT9XW0lgk26jC78qjf4+VbKIq7Xnmet9bO0K25A8A9ggwEbYv60KPhSeVbTlFt8a1cvthxmfhcgTBdX1JuZ+QbTt6Ex1Pq5efDM1XTKM9wDa1fEz2/+JTIAD6t6nOP8I45M7bRY/WyBXD1TNEU3XWDuJHRf9RlHgfALbc+GD4PHa6/QvWv6gmAAfeGMWbTnl/bDIk6zghfLcM9NhiZErz9V+AX7uQPlKSzqsz/WtjCthz4nFltNVisKftFLZieOR0QOJNDo10KPAbMnRk5R/5znlMd/zyH7C2oGlMCAjVK5GETJnRyw26/y0S5PWwxovf3p+IjXeNrRiHmsiSiVUK/e9EPiSya5n/GPRR9x9VoYEmo9fS88g8+Buo=

--- a/lib/talis/bibliography.rb
+++ b/lib/talis/bibliography.rb
@@ -41,12 +41,12 @@ module Talis
       klass.new(data: [], meta: meta).extend(ResultSet)
     end
 
-    # rubocop:disable Metrics/LineLength
     def escape_query(query_string)
       # TODO: are all of these necessary?
-      pattern = %r((\+|\-|\=|\&\&|\|\||\>|\<|\!|\(|\)|\{|\}|\[|\]|\^|\"|\~|\*|\?|\:|\\|\/))
+      pattern = %r{
+        (\+|\-|\=|\&\&|\|\||\>|\<|\!|\(|\)|\{|\}|\[|\]|\^|\"|\~|\*|\?|\:|\\|\/)
+      }x
       query_string.gsub(pattern) { |match| "\\#{match}" }
     end
-    # rubocop:enable Metrics/LineLength
   end
 end

--- a/lib/talis/bibliography.rb
+++ b/lib/talis/bibliography.rb
@@ -41,9 +41,12 @@ module Talis
       klass.new(data: [], meta: meta).extend(ResultSet)
     end
 
+    # rubocop:disable Metrics/LineLength
     def escape_query(query_string)
-      pattern = /(\+|\-|\=|\&\&|\|\||\>|\<|\!|\(|\)|\{|\}|\[|\]|\^|\"|\~|\*|\?|\:|\\|\/)/
-      query_string.gsub(pattern) { |match| "\\" +  match }
+      # TODO: are all of these necessary?
+      pattern = %r((\+|\-|\=|\&\&|\|\||\>|\<|\!|\(|\)|\{|\}|\[|\]|\^|\"|\~|\*|\?|\:|\\|\/))
+      query_string.gsub(pattern) { |match| "\\#{match}" }
     end
+    # rubocop:enable Metrics/LineLength
   end
 end

--- a/lib/talis/bibliography.rb
+++ b/lib/talis/bibliography.rb
@@ -40,5 +40,10 @@ module Talis
       meta = OpenStruct.new(meta_properties)
       klass.new(data: [], meta: meta).extend(ResultSet)
     end
+
+    def escape_query(query_string)
+      pattern = /(\+|\-|\=|\&\&|\|\||\>|\<|\!|\(|\)|\{|\}|\[|\]|\^|\"|\~|\*|\?|\:|\\|\/)/
+      query_string.gsub(pattern) { |match| "\\" +  match }
+    end
   end
 end

--- a/lib/talis/bibliography/work.rb
+++ b/lib/talis/bibliography/work.rb
@@ -41,7 +41,8 @@ module Talis
         # @raise [Talis::ServerError] if the search failed on the
         #   server.
         # @raise [Talis::ServerCommunicationError] for network issues.
-        def find(request_id: new_req_id, query:, offset: 0, limit: 20, include: [])
+        def find(request_id: new_req_id, query:, offset: 0, limit: 20, include: [], opts: {})
+          query = escape_query(query) if opts[:escape_query]
           api_client(request_id).work(token, query, limit, offset,
                                       include: include)
                                 .extend(ResultSet).hydrate

--- a/lib/talis/bibliography/work.rb
+++ b/lib/talis/bibliography/work.rb
@@ -24,10 +24,11 @@ module Talis
         # Search for bibliographic works
         # @param request_id [String] ('uuid') unique ID for the remote request.
         # @param query [String] the query to filter works on
-        # @param offset [Integer] the page offset
-        # @param limit [Integer] the number of works per page
         # @param include [Array] the related resources to associate with each work
         #   see {https://github.com/talis/metatron_rb/blob/master/docs/DefaultApi.md#2_works_get}
+        # @param opts [Hash] Can include key/value pairs for offset (default: 0),
+        #   limit (default 20), and escape_query (boolean), which will escape any
+        #   reserved characters from the query parameter
         # @return [MetatronClient::WorkResultSet] containing data and meta attributes.
         #   The structure is as follows:
         #     {

--- a/lib/talis/version.rb
+++ b/lib/talis/version.rb
@@ -1,3 +1,3 @@
 module Talis
-  VERSION = '0.8.5'.freeze
+  VERSION = '0.9.0'.freeze
 end

--- a/spec/integration/bibliography/work_spec.rb
+++ b/spec/integration/bibliography/work_spec.rb
@@ -59,10 +59,10 @@ describe Talis::Bibliography::Work do
                  '[foobar]', 'the~tenticle', 'have you seen my ^', ':foo:',
                  '(some query', 'some query)', '"some query']
       queries.each do |query|
-        expect{
+        expect do
           Talis::Bibliography::Work.find(query: query,
                                          opts: { offset: 0, limit: 1 })
-        }.to raise_error(Talis::BadRequestError)
+        end.to raise_error(Talis::BadRequestError)
       end
     end
 
@@ -72,8 +72,8 @@ describe Talis::Bibliography::Work do
                  '(some query', 'some query)', '"some query']
       queries.each do |query|
         works = Talis::Bibliography::Work.find(query: query,
-                                                opts: { offset: 0, limit: 1,
-                                                        escape_query: true })
+                                               opts: { offset: 0, limit: 1,
+                                                       escape_query: true })
         expect(works).to be_a(MetatronClient::WorkResultSet)
         expect(works).to be_a(Talis::Bibliography::ResultSet)
       end

--- a/spec/integration/bibliography/work_spec.rb
+++ b/spec/integration/bibliography/work_spec.rb
@@ -10,8 +10,8 @@ describe Talis::Bibliography::Work do
 
   context 'searching works' do
     it 'returns works when given a valid query' do
-      works = Talis::Bibliography::Work.find(query: 'rockclimbing', offset: 0,
-                                             limit: 1)
+      works = Talis::Bibliography::Work.find(query: 'rockclimbing',
+                                             opts: { offset: 0, limit: 1 })
       expect(works).to be_a(MetatronClient::WorkResultSet)
       expect(works.first).to be_a(Talis::Bibliography::Work)
       expect(works.first).to eq works.data.first
@@ -19,8 +19,8 @@ describe Talis::Bibliography::Work do
     end
 
     it 'hydrates manifestations when they are included' do
-      works = Talis::Bibliography::Work.find(query: 'rockclimbing', offset: 0,
-                                             limit: 1,
+      works = Talis::Bibliography::Work.find(query: 'rockclimbing',
+                                             opts: { offset: 0, limit: 1 },
                                              include: ['manifestations'])
       expect(works).to be_a(MetatronClient::WorkResultSet)
       expect(works.first).to be_a(Talis::Bibliography::Work)
@@ -32,7 +32,7 @@ describe Talis::Bibliography::Work do
 
     it 'hydrates assets when they are included' do
       works = Talis::Bibliography::Work.find(
-        query: 'rockclimbing', offset: 0, limit: 1,
+        query: 'rockclimbing', opts: { offset: 0, limit: 1 },
         include: ['manifestations.assets']
       )
       expect(works).to be_a(MetatronClient::WorkResultSet)
@@ -45,8 +45,8 @@ describe Talis::Bibliography::Work do
     end
 
     it 'should return an empty WorkResult if there are no query matches' do
-      works = Talis::Bibliography::Work.find(query: 'hicvnafih', offset: 0,
-                                             limit: 1)
+      works = Talis::Bibliography::Work.find(query: 'hicvnafih',
+                                             opts: { offset: 0, limit: 1 })
       expect(works).to be_a(MetatronClient::WorkResultSet)
       expect(works.data).to be_empty
       expect(works.meta.count).to eq 0

--- a/spec/unit/bibliography/work_spec.rb
+++ b/spec/unit/bibliography/work_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../spec_helper'
 
 describe Talis::Bibliography::Work do
-  let(:request_id) { 'request-id-123' }
+  let(:request_id) { 'a1b2c3d4e5f60' }
   context 'escaping works search queries' do
     it 'should not escape reserved characters in query by default' do
       query = '"/the + quick - brown: = fo\x && jumps || {over} > the <' \

--- a/spec/unit/bibliography/work_spec.rb
+++ b/spec/unit/bibliography/work_spec.rb
@@ -6,10 +6,12 @@ describe Talis::Bibliography::Work do
     it 'should not escape reserved characters in query by default' do
       query = '"/the + quick - brown: = fo\x && jumps || {over} > the <' \
         ' (lazy) ~ dog?!'
-      allow(Talis::Bibliography::Work).to receive(:search_works).with(
-        request_id, query, 0, 20, []
-      )
+      params = { q: query, offset: 0, limit: 20, include: '' }
+      search_url = stub_metatron_request(request_id, params)
+      expect(Talis::Bibliography::Work).to receive(:token).and_return('foobar')
+
       Talis::Bibliography::Work.find(request_id: request_id, query: query)
+      expect(a_request(:get, search_url).with(query: params)).to have_been_made
     end
 
     it 'should escape reserved characters if requested' do
@@ -17,69 +19,106 @@ describe Talis::Bibliography::Work do
         ' (lazy) ~ dog?!'
       expected_query = '\"\/the \+ quick \- brown\: \= fo\\\x \&& jumps \||' \
         ' \{over\} \> the \< \(lazy\) \~ dog\?\!'
-      allow(Talis::Bibliography::Work).to receive(:search_works).with(
-        request_id, expected_query, 0, 20, []
-      )
+
+      params = { q: expected_query, offset: 0, limit: 20, include: '' }
+      search_url = stub_metatron_request(request_id, params)
+      expect(Talis::Bibliography::Work).to receive(:token).and_return('foobar')
+
       Talis::Bibliography::Work.find(request_id: request_id, query: query,
                                      include: [], opts: { escape_query: true })
+      expect(a_request(:get, search_url).with(query: params)).to have_been_made
     end
   end
 
   context 'passing search options' do
     it 'should set defaults for includes, offset, and limit' do
-      query = 'foo bar baz'
-      allow(Talis::Bibliography::Work).to receive(:search_works).with(
-        request_id, query, 0, 20, []
-      )
-      Talis::Bibliography::Work.find(request_id: request_id, query: query)
+      params = { q: 'foo bar baz', offset: 0, limit: 20, include: '' }
+      search_url = stub_metatron_request(request_id, params)
+      expect(Talis::Bibliography::Work).to receive(:token).and_return('foobar')
+      Talis::Bibliography::Work.find(request_id: request_id, query: params[:q])
+      expect(a_request(:get, search_url).with(query: params)).to have_been_made
     end
 
     it 'should offset to be specified without limit' do
-      query = 'foo bar baz'
-      allow(Talis::Bibliography::Work).to receive(:search_works).with(
-        request_id, query, 31, 20, []
-      )
-      Talis::Bibliography::Work.find(request_id: request_id, query: query,
+      params = { q: 'foo bar baz', offset: 31, limit: 20, include: '' }
+      search_url = stub_metatron_request(request_id, params)
+      expect(Talis::Bibliography::Work).to receive(:token).and_return('foobar')
+      Talis::Bibliography::Work.find(request_id: request_id, query: params[:q],
                                      opts: { offset: 31 })
+      expect(a_request(:get, search_url).with(query: params)).to have_been_made
     end
 
     it 'should limit to be specified without offset' do
-      query = 'foo bar baz'
-      allow(Talis::Bibliography::Work).to receive(:search_works).with(
-        request_id, query, 0, 13, []
-      )
-      Talis::Bibliography::Work.find(request_id: request_id, query: query,
+      params = { q: 'foo bar baz', offset: 0, limit: 13, include: '' }
+      search_url = stub_metatron_request(request_id, params)
+      expect(Talis::Bibliography::Work).to receive(:token).and_return('foobar')
+      Talis::Bibliography::Work.find(request_id: request_id, query: params[:q],
                                      opts: { limit: 13 })
+      expect(a_request(:get, search_url).with(query: params)).to have_been_made
     end
 
     it 'should both offset and limit to be specified' do
-      query = 'foo bar baz'
-      allow(Talis::Bibliography::Work).to receive(:search_works).with(
-        request_id, query, 31, 13, []
-      )
-      Talis::Bibliography::Work.find(request_id: request_id, query: query,
+      params = { q: 'foo bar baz', offset: 31, limit: 13, include: '' }
+      search_url = stub_metatron_request(request_id, params)
+      expect(Talis::Bibliography::Work).to receive(:token).and_return('foobar')
+
+      Talis::Bibliography::Work.find(request_id: request_id, query: params[:q],
                                      opts: { offset: 31, limit: 13 })
+      expect(a_request(:get, search_url).with(query: params)).to have_been_made
     end
 
     it 'should allow include to be specified' do
-      query = 'foo bar baz'
-      allow(Talis::Bibliography::Work).to receive(:search_works).with(
-        request_id, query, 0, 20, ['manifestations.assets']
-      )
-
-      Talis::Bibliography::Work.find(request_id: request_id, query: query,
+      params = { q: 'foo bar baz', offset: 0, limit: 20,
+                 include: 'manifestations.assets' }
+      search_url = stub_metatron_request(request_id, params)
+      expect(Talis::Bibliography::Work).to receive(:token).and_return('foobar')
+      Talis::Bibliography::Work.find(request_id: request_id, query: params[:q],
                                      include: ['manifestations.assets'])
+      expect(a_request(:get, search_url).with(query: params)).to have_been_made
     end
 
     it 'should accept and pass all supplied options' do
-      allow(Talis::Bibliography::Work).to receive(:search_works).with(
-        request_id, '\:foo\:', 10, 50, ['manifestations.assets']
-      )
-
+      params = { q: '\:foo\:', offset: 10, limit: 50,
+                 include: 'manifestations.assets' }
+      search_url = stub_metatron_request(request_id, params)
+      expect(Talis::Bibliography::Work).to receive(:token).and_return('foobar')
       Talis::Bibliography::Work.find(request_id: request_id, query: ':foo:',
                                      include: ['manifestations.assets'],
                                      opts: { offset: 10, limit: 50,
                                              escape_query: true })
+      expect(a_request(:get, search_url).with(query: params)).to have_been_made
     end
+  end
+
+  def stub_metatron_request(request_id, params)
+    url = stub_url
+    stub_request(:get, url).with(headers: request_headers(request_id),
+                                 query: params)
+                           .to_return(status: 200, body: empty_result_body,
+                                      headers: {})
+    url
+  end
+
+  def stub_url
+    url = Talis::Bibliography::Work.base_uri
+    base_path = if ENV['METATRON_BASE_PATH']
+                  "#{ENV['METATRON_BASE_PATH']}/works"
+                else
+                  '/2/works'
+                end
+
+    url << base_path unless url.match(base_path)
+    url
+  end
+
+  def empty_result_body
+    '{ "meta": { "count": 0, "offset": 0, "limit": 20 }, "data": [] }'
+  end
+
+  def request_headers(request_id)
+    { 'Accept' => 'application/vnd.api+json',
+      'Authorization' => 'Bearer ',
+      'Content-Type' => 'application/json',
+      'X-Request-Id' => request_id }
   end
 end

--- a/spec/unit/bibliography/work_spec.rb
+++ b/spec/unit/bibliography/work_spec.rb
@@ -1,0 +1,85 @@
+require_relative '../spec_helper'
+
+describe Talis::Bibliography::Work do
+  let(:request_id) { 'request-id-123' }
+  context 'escaping works search queries' do
+    it 'should not escape reserved characters in query by default' do
+      query = '"/the + quick - brown: = fo\x && jumps || {over} > the <' \
+        ' (lazy) ~ dog?!'
+      allow(Talis::Bibliography::Work).to receive(:search_works).with(
+        request_id, query, 0, 20, []
+      )
+      Talis::Bibliography::Work.find(request_id: request_id, query: query)
+    end
+
+    it 'should escape reserved characters if requested' do
+      query = '"/the + quick - brown: = fo\x && jumps || {over} > the <' \
+        ' (lazy) ~ dog?!'
+      expected_query = '\"\/the \+ quick \- brown\: \= fo\\\x \&& jumps \||' \
+        ' \{over\} \> the \< \(lazy\) \~ dog\?\!'
+      allow(Talis::Bibliography::Work).to receive(:search_works).with(
+        request_id, expected_query, 0, 20, []
+      )
+      Talis::Bibliography::Work.find(request_id: request_id, query: query,
+                                     include: [], opts: { escape_query: true })
+    end
+  end
+
+  context 'passing search options' do
+    it 'should set defaults for includes, offset, and limit' do
+      query = 'foo bar baz'
+      allow(Talis::Bibliography::Work).to receive(:search_works).with(
+        request_id, query, 0, 20, []
+      )
+      Talis::Bibliography::Work.find(request_id: request_id, query: query)
+    end
+
+    it 'should offset to be specified without limit' do
+      query = 'foo bar baz'
+      allow(Talis::Bibliography::Work).to receive(:search_works).with(
+        request_id, query, 31, 20, []
+      )
+      Talis::Bibliography::Work.find(request_id: request_id, query: query,
+                                     opts: { offset: 31 })
+    end
+
+    it 'should limit to be specified without offset' do
+      query = 'foo bar baz'
+      allow(Talis::Bibliography::Work).to receive(:search_works).with(
+        request_id, query, 0, 13, []
+      )
+      Talis::Bibliography::Work.find(request_id: request_id, query: query,
+                                     opts: { limit: 13 })
+    end
+
+    it 'should both offset and limit to be specified' do
+      query = 'foo bar baz'
+      allow(Talis::Bibliography::Work).to receive(:search_works).with(
+        request_id, query, 31, 13, []
+      )
+      Talis::Bibliography::Work.find(request_id: request_id, query: query,
+                                     opts: { offset: 31, limit: 13 })
+    end
+
+    it 'should allow include to be specified' do
+      query = 'foo bar baz'
+      allow(Talis::Bibliography::Work).to receive(:search_works).with(
+        request_id, query, 0, 20, ['manifestations.assets']
+      )
+
+      Talis::Bibliography::Work.find(request_id: request_id, query: query,
+                                     include: ['manifestations.assets'])
+    end
+
+    it 'should accept and pass all supplied options' do
+      allow(Talis::Bibliography::Work).to receive(:search_works).with(
+        request_id, '\:foo\:', 10, 50, ['manifestations.assets']
+      )
+
+      Talis::Bibliography::Work.find(request_id: request_id, query: ':foo:',
+                                     include: ['manifestations.assets'],
+                                     opts: { offset: 10, limit: 50,
+                                             escape_query: true })
+    end
+  end
+end


### PR DESCRIPTION
By default, `Bibliography::Works.find` queries are not escaped for ElasticSearch reserved characters, which will throw an exception on Metatron's end.  There's no reason a simple keyword query should have to keep up with what's valid or not, so this gives the option to pass an `escape_query: true` option to `find` which will escape any reserved characters in the query string.